### PR TITLE
Fix invalid operation error by correctly accessing xurls.Relaxed as var

### DIFF
--- a/parsers/regex.go
+++ b/parsers/regex.go
@@ -19,7 +19,8 @@ func (p *RegexParser) Parse(r io.Reader) ([]string, error) {
 
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
-		for _, target := range xurls.Relaxed().FindAllString(scanner.Text(), -1) {
+		// Use xurls.Relaxed directly if it's a *regexp.Regexp variable
+		for _, target := range xurls.Relaxed.FindAllString(scanner.Text(), -1) {
 			if _, found := targetsFilter[target]; found {
 				continue
 			}


### PR DESCRIPTION
## Summary:

This PR addresses an issue in parsers/regex.go where xurls.Relaxed was incorrectly treated as a function call. According to the error message encountered, xurls.Relaxed is a variable of type *regexp.Regexp within the github.com/mvdan/xurls package, not a function. This mismatch led to a compilation error, preventing the successful execution of the code.

## Changes:

Modified the invocation of xurls.Relaxed in RegexParser.Parse method to directly access the variable instead of attempting to call it as a function. This aligns with the expected type of xurls.Relaxed as a *regexp.Regexp.

## Impact:

Resolves the compilation error, allowing the RegexParser to correctly utilize the xurls.Relaxed regular expression for finding URLs in text. Enhances the reliability and maintainability of the code by ensuring compatibility with the current xurls package API.